### PR TITLE
ci: don't tag sentry

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -38,9 +38,3 @@ jobs:
       - name: Test
         run: echo "deploy!"
 
-  tag-sentry:
-    needs: deploy-staging
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash


### PR DESCRIPTION
Remove sentry from CI
We're testing release drafting